### PR TITLE
Fixed link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A sample entry validation using Behaviors and XAML in Xamarin Forms
 
 This sample is based on this article:
 
-https://blog.xamarin.com/behaviors-in-xamarin-forms/
+https://devblogs.microsoft.com/xamarin/behaviors-in-xamarin-forms/
 
 
 But I need to attach multiple validators (behaviors) on a Entry field and get which validator fails to display the right the right error message. 


### PR DESCRIPTION
They've moved the xamarin blogs to devblogs.microsoft.com